### PR TITLE
Dev updated 01feb23 (for `metric_summary` template)

### DIFF
--- a/metric_summary/install.R
+++ b/metric_summary/install.R
@@ -1,4 +1,2 @@
-BiocManager::install('jsonlite')
-install.packages("R.utils")
-install.packages("dplyr")
-install.packages("magrittr")
+pkgs <- c("jsonlite","R.utils","dplyr","magrittr","reticulate")
+BiocManager::install(pkg)

--- a/metric_summary/install.R
+++ b/metric_summary/install.R
@@ -1,2 +1,2 @@
 pkgs <- c("jsonlite","R.utils","dplyr","magrittr","reticulate")
-BiocManager::install(pkg)
+BiocManager::install(pkgs)

--- a/metric_summary/requirements.txt
+++ b/metric_summary/requirements.txt
@@ -1,2 +1,2 @@
-omnibenchmark==0.0.30
+omnibenchmark==0.0.39
 git+https://github.com/ansonrel/omni_sparql@main


### PR DESCRIPTION
- bumped `omnibenchmark` version to 0.0.39
- added `reticulate` to the list of R packages installed